### PR TITLE
Rpi qemufw

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ install:
   - export GCC_URL=https://launchpad.net/gcc-arm-embedded/5.0/5-2015-q4-major/+download/gcc-arm-none-eabi-5_2-2015q4-20151219-linux.tar.bz2
   - if [ ! -e $GCC_DIR/bin/arm-none-eabi-g++ ]; then wget $GCC_URL -O $GCC_ARCHIVE; tar xfj $GCC_ARCHIVE -C $HOME; fi
   - export PATH=$PATH:$GCC_DIR/bin
+  - export CROSS_COMPILE=$GCC_DIR/bin/arm-none-eabi-
 
 script: make
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
-ARMCC ?= arm-none-eabi-gcc
 MAKEFILE = Makefile.rpi-boot
 MAKEFILE_IN = $(MAKEFILE).in
+
+# Allow cross as well as native compilation
+CROSS_COMPILE  ?=
+ARMCC           = $(CROSS_COMPILE)gcc
 
 all: kernel.img
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ ARMCC           = $(CROSS_COMPILE)gcc
 
 all: kernel.img
 
-.PHONY: clean kernel.img libfs.a qemu qemu-gdb dump kernel-qemu.elf kernel.img-atag
+.PHONY: clean kernel.img libfs.a qemu qemu-gdb dump kernel-qemu.elf kernel.img-atag qemufw.elf
 
 $(MAKEFILE): $(MAKEFILE_IN) config.h Makefile
 	$(ARMCC) -P -traditional-cpp -std=gnu99 -E -o $(MAKEFILE) -x c $(MAKEFILE_IN)
@@ -26,6 +26,9 @@ libfs.a: $(MAKEFILE)
 
 kernel-qemu.elf: $(MAKEFILE)
 	$(MAKE) -f $(MAKEFILE) kernel-qemu.elf
+
+qemufw.elf: $(MAKEFILE)
+	$(MAKE) -f $(MAKEFILE) qemufw.elf
 
 qemu: $(MAKEFILE)
 	$(MAKE) -f $(MAKEFILE) qemu

--- a/Makefile.rpi-boot.in
+++ b/Makefile.rpi-boot.in
@@ -122,6 +122,7 @@ OBJS += printf.o $(SD_OBJS) block.o $(MBR_OBJS) $(FAT_OBJS) vfs.o multiboot.o
 OBJS += memchunk.o $(EXT2_OBJS) elf.o timer.o strtol.o strtoll.o $(ASSERT_OBJS)
 OBJS += ctype.o $(USB_OBJS) output.o $(RASPBOOTIN_OBJS) $(RAMDISK_OBJS)
 OBJS += $(NOFS_OBJS) $(CACHE_OBJS) $(LOGFILE_OBJS) crc32.o rpifdt.o strstr.o
+OBJS += config_parse.o
 
 LIBFS_OBJS = libfs.o $(SD_OBJS) block.o $(MBR_OBJS) $(FAT_OBJS) vfs.o $(EXT2_OBJS) timer.o mmio.o $(RASPBOOTIN_OBJS) $(RAMDISK_OBJS) $(NOFS_OBJS) $(CACHE_OBJS) crc32.o $(ASSERT_OBJS)
 

--- a/Makefile.rpi-boot.in
+++ b/Makefile.rpi-boot.in
@@ -1,10 +1,14 @@
 #include "config.h"
 
-ARMCC ?= arm-none-eabi-gcc
-ARMLD ?= arm-none-eabi-ld
-ARMOBJCOPY ?= arm-none-eabi-objcopy
-ARMOBJDUMP ?= arm-none-eabi-objdump
-ARMAR ?= arm-none-eabi-ar
+/* Allow cross as well as native compilation */
+CROSS_COMPILE  ?=
+HOSTCC          = $(CC)
+ARMCC          ?= $(CROSS_COMPILE)gcc
+ARMLD          ?= $(CROSS_COMPILE)ld
+ARMOBJCOPY     ?= $(CROSS_COMPILE)objcopy
+ARMOBJDUMP     ?= $(CROSS_COMPILE)objdump
+ARMAR          ?= $(CROSS_COMPILE)ar
+
 QEMU ?= qemu-system-arm
 
 QEMUDTB ?= bcm2709-rpi-2-b.dtb

--- a/Makefile.rpi-boot.in
+++ b/Makefile.rpi-boot.in
@@ -33,9 +33,13 @@ ASSERT_OBJS = assert.o
 CFLAGS += -O3
 #endif
 
+#ifdef __aarch64__
+QEMUFLAGS += -m 1G -M raspi3 -kernel kernel-qemu.img -usb -nographic
+CFLAGS += -mgeneral-regs-only
+#else
 ASFLAGS += -Wa,-mcpu=arm1176jzf-s
-
 QEMUFLAGS += -cpu arm1176 -m 256 -M raspi2 -kernel kernel-qemu.img -usb -nographic -dtb $(QEMUDTB)
+#endif
 SDFLAGS = -sd sd.img
 
 #ifdef ENABLE_FRAMEBUFFER
@@ -107,7 +111,17 @@ $(FONT_OBJS): $(FONT_BIN) $(MAKEFILE) $(CONFIG_H)
 MBR_OBJS = mbr.o
 #endif
 
-OBJS = main.o boot.o libfs.o $(SERIAL_OBJS) stdio.o stream.o atag.o mbox.o $(FONT_OBJS) $(FB_OBJS) stdlib.o mmio.o heap.o malloc.o printf.o $(SD_OBJS) block.o $(MBR_OBJS) $(FAT_OBJS) vfs.o multiboot.o memchunk.o $(EXT2_OBJS) elf.o timer.o strtol.o strtoll.o $(ASSERT_OBJS) ctype.o $(USB_OBJS) output.o $(RASPBOOTIN_OBJS) $(RAMDISK_OBJS) $(NOFS_OBJS) $(CACHE_OBJS) $(LOGFILE_OBJS) crc32.o rpifdt.o strstr.o
+#ifdef __aarch64__
+OBJS  = boot64.o
+#else
+OBJS  = boot.o
+#endif
+OBJS += main.o libfs.o $(SERIAL_OBJS) stdio.o stream.o atag.o
+OBJS += mbox.o $(FONT_OBJS) $(FB_OBJS) stdlib.o mmio.o heap.o malloc.o
+OBJS += printf.o $(SD_OBJS) block.o $(MBR_OBJS) $(FAT_OBJS) vfs.o multiboot.o 
+OBJS += memchunk.o $(EXT2_OBJS) elf.o timer.o strtol.o strtoll.o $(ASSERT_OBJS)
+OBJS += ctype.o $(USB_OBJS) output.o $(RASPBOOTIN_OBJS) $(RAMDISK_OBJS)
+OBJS += $(NOFS_OBJS) $(CACHE_OBJS) $(LOGFILE_OBJS) crc32.o rpifdt.o strstr.o
 
 LIBFS_OBJS = libfs.o $(SD_OBJS) block.o $(MBR_OBJS) $(FAT_OBJS) vfs.o $(EXT2_OBJS) timer.o mmio.o $(RASPBOOTIN_OBJS) $(RAMDISK_OBJS) $(NOFS_OBJS) $(CACHE_OBJS) crc32.o $(ASSERT_OBJS)
 

--- a/Makefile.rpi-boot.in
+++ b/Makefile.rpi-boot.in
@@ -126,6 +126,8 @@ OBJS += config_parse.o
 
 LIBFS_OBJS = libfs.o $(SD_OBJS) block.o $(MBR_OBJS) $(FAT_OBJS) vfs.o $(EXT2_OBJS) timer.o mmio.o $(RASPBOOTIN_OBJS) $(RAMDISK_OBJS) $(NOFS_OBJS) $(CACHE_OBJS) crc32.o $(ASSERT_OBJS)
 
+QEMUFW_OBJS = qemufw.o
+
 .PHONY: clean
 .PHONY: qemu
 .PHONY: qemu-gdb
@@ -139,6 +141,9 @@ dump: $(DISASM_DUMP)
 
 libfs.a: $(LIBFS_OBJS)
 	$(ARMAR) rcs $@ $(LIBFS_OBJS)
+
+qemufw.elf: $(OBJS) qemufw.ld $(LIBFDT) $(QEMUFW_OBJS)
+	$(ARMCC) -nostdlib $(OBJS) $(QEMUFW_OBJS) -Wl,-T,qemufw.ld -o $@ -Llibdtc/libfdt -lfdt -lgcc
 
 kernel.elf: $(OBJS) linker.ld $(LIBFDT)
 	$(ARMCC) -nostdlib $(OBJS) -Wl,-T,linker.ld -o $@ -Llibdtc/libfdt -lfdt -lgcc
@@ -156,7 +161,7 @@ kernel-qemu.img: kernel-qemu.elf
 	$(ARMOBJCOPY) kernel-qemu.elf -O binary kernel-qemu.img
 
 clean:
-	$(RM) -f $(OBJS) $(DISASM_DUMP) kernel.elf kernel.img kernel-qemu.img kernel-qemu.elf $(MAKEFILE) kernel.img-preheader kernel.img-atag libfs.a assert.o
+	$(RM) -f $(OBJS) $(DISASM_DUMP) kernel.elf kernel.img kernel-qemu.img kernel-qemu.elf $(MAKEFILE) kernel.img-preheader kernel.img-atag libfs.a assert.o $(QEMUFW_OBJS)
 
 %.o: %.c $(MAKEFILE) $(CONFIG_H)
 	$(ARMCC) $(CFLAGS) -include $(CONFIG_H) -c $< -o $@

--- a/atag.c
+++ b/atag.c
@@ -27,7 +27,7 @@
 
 extern const char *atag_cmd_line;
 extern int conf_source;
-extern uint32_t _atags;
+extern uintptr_t _atags;
 
 int check_atags(const void *atags)
 {
@@ -37,7 +37,8 @@ int check_atags(const void *atags)
 	return -1;
 }
 
-void parse_atags(uint32_t atags, void (*mem_cb)(uint32_t addr, uint32_t len))
+void parse_atags(uintptr_t atags,
+                 void (*mem_cb)(uint32_t addr, uint32_t len))
 {
 	if(atags == 0)
 		return;

--- a/atag.h
+++ b/atag.h
@@ -121,7 +121,7 @@ struct atag
 };
 
 int check_atags(const void *atags);
-void parse_atags(uint32_t atags, void (*mem_cb)(uint32_t addr, uint32_t len));
+void parse_atags(uintptr_t atags, void (*mem_cb)(uint32_t addr, uint32_t len));
 
 void parse_atag_or_dtb(void (*mem_cb)(uint32_t addr, uint32_t len));
 

--- a/boot64.s
+++ b/boot64.s
@@ -1,0 +1,90 @@
+/* Copyright (C) 2013 by John Cronin <jncronin@tysos.org>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+.section ".text.boot"
+
+.globl Start
+
+Start:
+	adr	x20, stack + (1 << 15)
+	mov	sp, x20
+
+	/* Clear out bss */
+	ldr	x4, =_bss_start
+	ldr	x9, =_bss_end
+	mov	x5, #0
+	mov	x6, #0
+
+	b	.test
+
+.loop:
+	/* this does 2x8 = 16 byte stores at once */
+	stp	x5, x6, [x4, #0]
+	add	x4, x4, #16
+.test:
+	cmp	x4, x9
+	blo	.loop
+
+	/* branch and link to kernel_main */
+	bl	kernel_main
+
+halt:
+	wfe		/* equivalent of x86 HLT instruction */
+	b	halt
+
+.globl flush_cache
+flush_cache:
+	mov 	x0, #0
+	/* XXX, not used in QEMU */
+	ret
+
+.globl memory_barrier
+memory_barrier:
+	mov	x0, #0
+	dmb	sy
+	ret
+
+.globl read_sctlr
+read_sctlr:
+	mrs	x0, sctlr_el2
+	ret
+
+.globl quick_memcpy
+quick_memcpy:
+	mov	x10, x0
+	mov	x11, x1
+
+.loopb:
+	ldp	x12, x13, [x11, #0]
+	add	x11, x11, #16
+	stp	x12, x13, [x10, #0]
+	add	x10, x10, #16
+	sub	x2, x2, #16
+	cmp	x2, #0
+	bhi	.loopb
+
+	ret
+
+.section ".bss"
+	.align 4		/* Align on 128bit boundary */
+	stack:
+	.align 15		/* Reserve 32kb of stack */
+

--- a/config_parse.c
+++ b/config_parse.c
@@ -83,7 +83,7 @@ static char *strip_comments(char *buf)
 
 const char empty_string[] = "";
 
-void split_string(char *str, char **method, char **args)
+void split_string(char *str, char delim, char **method, char **args)
 {
 	int state = 0;
 	char *p = str;
@@ -95,9 +95,12 @@ void split_string(char *str, char **method, char **args)
 	*method = (char*)empty_string;
 	*args = (char*)empty_string;
 
+	if (!delim)
+		delim = ' ';
+
 	while(*p)
 	{
-		if(*p == ' ')
+		if(*p == delim)
 		{
 			if(state == 1)
 			{
@@ -122,7 +125,8 @@ void split_string(char *str, char **method, char **args)
 	}
 }
 
-int config_parse(char *buf, const struct config_parse_method *methods)
+int config_parse(char *buf, char delim,
+		 const struct config_parse_method *methods)
 {
 	char *line;
 	char *b = buf;
@@ -135,7 +139,7 @@ int config_parse(char *buf, const struct config_parse_method *methods)
 		printf("read_line: %s\n", line);
 #endif
 		char *method, *args;
-		split_string(line, &method, &args);
+		split_string(line, delim, &method, &args);
 #ifdef MULTIBOOT_DEBUG
 		printf("method: %s, args: %s\n", method, args);
 #endif

--- a/config_parse.c
+++ b/config_parse.c
@@ -1,0 +1,176 @@
+/* Copyright (C) 2013 by John Cronin <jncronin@tysos.org>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+// Parses the .cfg file
+
+#include "config_parse.h"
+#include "ctype.h"
+#include "stdio.h"
+#include "stdlib.h"
+#include "string.h"
+
+static char *read_line(char **buf)
+{
+	char *start = *buf;
+	char *ptr = *buf;
+
+	if(!*start)
+		return (void*)0;
+	while((*ptr != 0) && (*ptr != '\n'))
+		ptr++;
+
+	if(*ptr == 0)
+	{
+		// End of the string
+		*buf = ptr;
+		return start;
+	}
+	else
+	{
+		// End of a line - null terminate
+		*ptr = 0;
+		ptr++;
+		*buf = ptr;
+		return start;
+	}
+}
+
+/* Remove leading and trailing whitespace and trailing comments from a configuration line */
+static char *strip_comments(char *buf)
+{
+	// Remove leading whitespace
+	while(isspace(*buf))
+		buf++;
+
+	// Remove comments
+	char *s = buf;
+	while(*s)
+	{
+		if(*s == '#')
+			*s = '\0';
+		else
+			s++;
+	}
+
+	// Remove trailing whitespace
+	s--;
+	while((s > buf) && isspace(*s))
+	{
+		*s = '\0';
+		s--;
+	}
+
+	return buf;
+}
+
+const char empty_string[] = "";
+
+void split_string(char *str, char **method, char **args)
+{
+	int state = 0;
+	char *p = str;
+
+	// state = 	0 - reading spaces before method
+	// 		1 - reading method
+	// 		2 - reading spaces before argument
+
+	*method = (char*)empty_string;
+	*args = (char*)empty_string;
+
+	while(*p)
+	{
+		if(*p == ' ')
+		{
+			if(state == 1)
+			{
+				*p = 0;	// null terminate method
+				state = 2;
+			}
+		}
+		else
+		{
+			if(state == 0)
+			{
+				*method = p;
+				state = 1;
+			}
+			else if(state == 2)
+			{
+				*args = p;
+				return;
+			}
+		}
+		p++;
+	}
+}
+
+int config_parse(char *buf, const struct config_parse_method *methods)
+{
+	char *line;
+	char *b = buf;
+	const struct config_parse_method *curmethod;
+
+	while((line = read_line(&b)))
+	{
+		line = strip_comments(line);
+#ifdef MULTIBOOT_DEBUG
+		printf("read_line: %s\n", line);
+#endif
+		char *method, *args;
+		split_string(line, &method, &args);
+#ifdef MULTIBOOT_DEBUG
+		printf("method: %s, args: %s\n", method, args);
+#endif
+
+		if(!strcmp(method, empty_string))
+			continue;
+
+		// Find and run the method
+		int found = 0;
+		char *lwr = strlwr(method);
+
+		for(curmethod = methods; curmethod->name; curmethod++)
+		{
+			if(!strcmp(lwr, curmethod->name))
+			{
+				found = 1;
+				int retno = curmethod->method(args);
+				if(retno != 0)
+				{
+					printf("cfg_parse: %s failed with "
+							"%i\n", line,
+							retno);
+					free(lwr);
+					return retno;
+				}
+				break;
+			}
+		}
+
+		free(lwr);
+
+		if(!found)
+			printf("cfg_parse: unknown method %s\n", method);
+	}
+
+	return 0;
+}
+

--- a/config_parse.h
+++ b/config_parse.h
@@ -1,0 +1,33 @@
+/* Copyright (C) 2013 by John Cronin <jncronin@tysos.org>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/* Helper to parse .cfg files */
+
+struct config_parse_method
+{
+	char *name;
+	int (*method)(char *args);
+};
+
+extern const char empty_string[];
+
+void split_string(char *str, char **method, char **args);
+int config_parse(char *buf, const struct config_parse_method *methods);

--- a/config_parse.h
+++ b/config_parse.h
@@ -25,9 +25,11 @@ struct config_parse_method
 {
 	char *name;
 	int (*method)(char *args);
+	char delim;
 };
 
 extern const char empty_string[];
 
-void split_string(char *str, char **method, char **args);
-int config_parse(char *buf, const struct config_parse_method *methods);
+void split_string(char *str, char delim, char **method, char **args);
+int config_parse(char *buf, char delim,
+		 const struct config_parse_method *methods);

--- a/elf.c
+++ b/elf.c
@@ -93,7 +93,7 @@ int elf32_read_shdrs(FILE *fp, Elf32_Ehdr *ehdr, uint8_t **shdrs)
 int elf32_load_section(FILE *fp, Elf32_Shdr *shdr)
 {
 	if(shdr->sh_type == SHT_NOBITS)
-		memset((void*)shdr->sh_addr, 0, shdr->sh_size);
+		memset((void*)(uintptr_t)shdr->sh_addr, 0, shdr->sh_size);
 	else
 	{
 		if(!shdr->sh_offset)
@@ -101,7 +101,7 @@ int elf32_load_section(FILE *fp, Elf32_Shdr *shdr)
 
 		fseek(fp, (long)shdr->sh_offset, SEEK_SET);
 		size_t bytes_to_read = (size_t)shdr->sh_size;
-		size_t bytes_read = fread((void *)shdr->sh_addr,
+		size_t bytes_read = fread((void *)(uintptr_t)shdr->sh_addr,
 				1, bytes_to_read, fp);
 		if(bytes_to_read != bytes_read)
 			return ELF_FILE_LOAD_ERROR;
@@ -125,7 +125,7 @@ int elf32_read_phdrs(FILE *fp, Elf32_Ehdr *ehdr, uint8_t **phdrs)
 
 int elf32_load_segment(FILE *fp, Elf32_Phdr *phdr)
 {
-	uint32_t load_address = phdr->p_vaddr;
+	uintptr_t load_address = phdr->p_vaddr;
 	if(phdr->p_filesz)
 	{
 		// Load the file image

--- a/emmc.c
+++ b/emmc.c
@@ -480,7 +480,7 @@ static uint32_t sd_get_base_clock_hz()
     capabilities_0 = mmio_read(emmc_base + EMMC_CAPABILITIES_0);
     base_clock = ((capabilities_0 >> 8) & 0xff) * 1000000;
 #elif SDHCI_IMPLEMENTATION == SDHCI_IMPLEMENTATION_BCM_2708
-	uint32_t mb_addr = 0x00007000;		// 0x7000 in L2 cache coherent mode
+	uintptr_t mb_addr = 0x00007000;		// 0x7000 in L2 cache coherent mode
 	volatile uint32_t *mailbuffer = (uint32_t *)mb_addr;
 
 	/* Get the base clock rate */
@@ -532,7 +532,7 @@ static uint32_t sd_get_base_clock_hz()
 #if SDHCI_IMPLEMENTATION == SDHCI_IMPLEMENTATION_BCM_2708
 static int bcm_2708_power_off()
 {
-	uint32_t mb_addr = 0x40007000;		// 0x7000 in L2 cache coherent mode
+	uintptr_t mb_addr = 0x40007000;		// 0x7000 in L2 cache coherent mode
 	volatile uint32_t *mailbuffer = (uint32_t *)mb_addr;
 
 	/* Power off the SD card */
@@ -581,7 +581,7 @@ static int bcm_2708_power_off()
 
 static int bcm_2708_power_on()
 {
-	uint32_t mb_addr = 0x40007000;		// 0x7000 in L2 cache coherent mode
+	uintptr_t mb_addr = 0x40007000;		// 0x7000 in L2 cache coherent mode
 	volatile uint32_t *mailbuffer = (uint32_t *)mb_addr;
 
 	/* Power on the SD card */

--- a/ext2.c
+++ b/ext2.c
@@ -502,6 +502,11 @@ struct dirent *ext2_read_dir(struct ext2_fs *fs, struct dirent *d)
 			uint16_t de_name_length = *(uint16_t *)&block[ptr + 6];
 			uint8_t de_type_flags = *(uint8_t *)&block[ptr + 7];
 
+			if (!de_entry_size) {
+				/* Invalid FS? */
+				break;
+			}
+
 			// Does the entry exist?
 			if(!de_inode_idx)
 			{

--- a/ext2.c
+++ b/ext2.c
@@ -257,7 +257,7 @@ static FILE *ext2_fopen(struct fs *fs, struct dirent *path, const char *mode)
 
 	// We have to load the inode to get the length
 	struct ext2_inode *inode = ext2_read_inode(ext2,
-			(uint32_t)path->opaque);
+			(uintptr_t)path->opaque);
 	ret->len = (long)inode->size;	// no support for large files
 	free(inode);
 
@@ -278,7 +278,7 @@ static size_t ext2_fread(struct fs *fs, void *ptr, size_t byte_size, FILE *strea
 		return -1;
 
 	struct ext2_inode *inode = ext2_read_inode((struct ext2_fs *)fs,
-		(uint32_t)stream->opaque);
+		(uintptr_t)stream->opaque);
 
 	return fs_fread(ext2_get_next_bdev_block_num, fs, ptr, byte_size, stream, (void *)inode);
 }
@@ -465,7 +465,7 @@ struct dirent *ext2_read_dir(struct ext2_fs *fs, struct dirent *d)
 
 	uint32_t inode_idx = 2;	// root
 	if(d != (void*)0)
-		inode_idx = (uint32_t)d->opaque;
+		inode_idx = (uintptr_t)d->opaque;
 
 	struct dirent *ret = (void *)0;
 	struct dirent *prev = (void *)0;
@@ -558,7 +558,7 @@ struct dirent *ext2_read_dir(struct ext2_fs *fs, struct dirent *d)
 			de->fs = &fs->b;
 			de->next = (void *)0;
 
-			de->opaque = (void*)de_inode_idx;
+			de->opaque = (void*)(uintptr_t)de_inode_idx;
 
 			ptr += de_entry_size;
 		}

--- a/fat.c
+++ b/fat.c
@@ -153,7 +153,7 @@ static size_t fat_fread(struct fs *fs, void *ptr, size_t byte_size, FILE *stream
 		return -1;
 
 	struct fat_file_block_offset opaque;
-	opaque.cluster = (uint32_t)stream->opaque;
+	opaque.cluster = (uintptr_t)stream->opaque;
 	opaque.f_block = 0;
 	return fs_fread(fat_get_next_bdev_block_num, fs, ptr, byte_size, stream, (void*)&opaque);
 }
@@ -445,7 +445,7 @@ struct dirent *fat_read_dir(struct fat_fs *fs, struct dirent *d)
 	if(is_root)
 		cur_cluster = fat->root_dir_cluster;
 	else
-		cur_cluster = (uint32_t)d->opaque;
+		cur_cluster = (uintptr_t)d->opaque;
 
 	struct dirent *ret = (void *)0;
 	struct dirent *prev = (void *)0;
@@ -535,7 +535,7 @@ struct dirent *fat_read_dir(struct fat_fs *fs, struct dirent *d)
 				de->is_dir = 1;
 			de->next = (void *)0;
 			de->byte_size = read_word(buf, ptr + 28);
-			uint32_t opaque = read_halfword(buf, ptr + 26) | 
+			uintptr_t opaque = read_halfword(buf, ptr + 26) | 
 				((uint32_t)read_halfword(buf, ptr + 20) << 16);
 
 			de->opaque = (void*)opaque;

--- a/fb.c
+++ b/fb.c
@@ -61,12 +61,12 @@
 #define TAG_SET_PALETTE			0x4800b
 
 static uint32_t phys_w, phys_h, virt_w, virt_h, pitch;
-static uint32_t fb_addr, fb_size;
+static uintptr_t fb_addr, fb_size;
 
 int fb_init()
 {
 	// define a mailbox buffer
-	uint32_t mb_addr = 0x7000;		// 0x7000 in L2 cache coherent mode
+	uintptr_t mb_addr = 0x7000;		// 0x7000 in L2 cache coherent mode
 	volatile uint32_t *mailbuffer = (uint32_t *)mb_addr;
 
 	/* Get the display size */

--- a/heap.c
+++ b/heap.c
@@ -22,7 +22,7 @@
 #include <stdint.h>
 #include <stdio.h>
 
-#define MAX_BRK 0xf0000
+#define MAX_BRK (((uintptr_t)&_start - 0x8000) + 0xf0000)
 
 #ifdef ENABLE_USB
 #include "dwc_usb.h"
@@ -31,7 +31,7 @@
 #define MAX_BUF 0x100000
 #endif
 
-extern char _end;
+extern char _start, _end;
 
 uintptr_t cur_brk = 0;
 uintptr_t cur_buf = MAX_BRK;

--- a/heap.c
+++ b/heap.c
@@ -33,7 +33,7 @@
 
 extern char _end;
 
-uint32_t cur_brk = 0;
+uintptr_t cur_brk = 0;
 uintptr_t cur_buf = MAX_BRK;
 
 uintptr_t alloc_buf(size_t size)
@@ -63,10 +63,10 @@ void *sbrk(uint32_t increment)
 	if(cur_brk == 0)
 	{
 #ifdef DEBUG2
-		printf("HEAP: initializing at %x\n", (uint32_t)&_end);
+		printf("HEAP: initializing at %p\n", &_end);
 #endif
 
-		cur_brk = (uint32_t)&_end;
+		cur_brk = (uintptr_t)&_end;
 		if(cur_brk & 0xfff)
 		{
 			cur_brk &= 0xfffff000;
@@ -74,7 +74,7 @@ void *sbrk(uint32_t increment)
 		}
 	}
 
-	uint32_t old_brk = cur_brk;
+	uintptr_t old_brk = cur_brk;
 
 	cur_brk += increment;
 	if(cur_brk >= MAX_BRK)

--- a/main.c
+++ b/main.c
@@ -39,9 +39,9 @@
 
 #define UNUSED(x) (void)(x)
 
-uint32_t _atags;
-uint32_t _arm_m_type;
-uint32_t base_adjust = 0;
+uintptr_t _atags;
+unsigned long _arm_m_type;
+uintptr_t base_adjust = 0;
 
 char rpi_boot_name[] = "rpi_boot";
 
@@ -80,7 +80,8 @@ int cfg_parse(char *buf);
 
 int conf_source = 0;
 
-void kernel_main(uint32_t boot_dev, uint32_t arm_m_type, uint32_t atags)
+void kernel_main(unsigned long boot_dev, unsigned long arm_m_type,
+                 unsigned long atags)
 {
 	// Hack for newer firmware - assume if atags not specified then they are at 0x100
 	// We also check the zero address in case this is true - see later

--- a/main.c
+++ b/main.c
@@ -84,109 +84,8 @@ int multiboot_cfg_parse(char *buf);
 
 int conf_source = 0;
 
-void kernel_main(unsigned long boot_dev, unsigned long arm_m_type,
-                 unsigned long atags)
+__attribute__((__weak__)) void find_and_run_config(void)
 {
-	// Hack for newer firmware - assume if atags not specified then they are at 0x100
-	// We also check the zero address in case this is true - see later
-	if(atags == 0x0)
-		atags = 0x100;
-	
-	atag_cmd_line = (void *)0;
-	_atags = atags;
-	_arm_m_type = arm_m_type;
-	UNUSED(boot_dev);
-
-	// First use the serial console
-	stdout_putc = split_putc;
-	stderr_putc = split_putc;
-	stream_putc = def_stream_putc;
-
-	output_init();
-	output_enable_uart();
-
-	// dump arguments to main
-#ifdef DEBUG
-	printf("MAIN: boot_dev: %x, arm_m_type: %i, atags: %x\n", boot_dev,
-			arm_m_type, atags);
-#endif
-
-	// try and interpret device tree/atags
-	if(fdt_check_header((const void *)atags) == 0)
-		conf_source = 3;
-	else if(fdt_check_header((const void *)0) == 0)
-		conf_source = 4;
-	else if(check_atags((const void *)atags) == 0)
-		conf_source = 1;
-	else if(check_atags((const void *)0) == 0)
-		conf_source = 2;
-
-	switch(conf_source)
-	{
-		case 1:
-		case 2:
-			// If using ATAGs, need to set up base adjust
-			// manually
-			if(arm_m_type == 0xc42)
-				base_adjust = BASE_ADJUST_V1;
-			else if(arm_m_type == 0xc43)
-				base_adjust = BASE_ADJUST_V2;
-			uart_init();
-#ifdef DEBUG
-			printf("ATAGS: detected\n");
-#endif
-
-			// Fall through
-		case 3:
-		case 4:
-			parse_atag_or_dtb(mem_cb);
-			break;
-		default:
-			printf("MAIN: ERROR no device tree or ATAGS found\n");
-			return;
-	}
-
-#ifdef ENABLE_FRAMEBUFFER
-	int result = fb_init();
-	if(result == 0)
-	{
-		puts("Successfully set up frame buffer");
-#ifdef DEBUG2
-		printf("FB: width: %i, height: %i, bpp: %i\n",
-			fb_get_width(), fb_get_height(),
-			fb_get_bpp());
-#endif
-	}
-	else
-	{
-		puts("Error setting up framebuffer:");
-		puthex(result);
-	}
-#endif
-
-	// Switch to the framebuffer for output
-	output_enable_fb();
-
-	// Allocate a log in memory
-#ifdef ENABLE_CONSOLE_LOGFILE
-	register_log_file(NULL, 0x1000);
-	output_enable_log();
-#endif
-
-	printf("Welcome to Rpi bootloader\n");
-	printf("Compiled on %s at %s\n", __DATE__, __TIME__);
-	printf("ARM system type is %x\n", arm_m_type);
-	if(atag_cmd_line != (void *)0)
-		printf("Command line: %s\n", atag_cmd_line);
-
-    // Register the various file systems
-	libfs_init();
-
-	// List devices
-	printf("MAIN: device list: ");
-	vfs_list_devices();
-	printf("\n");
-
 	// Look for a boot configuration file, starting with the default device,
 	// then iterating through all devices
 
@@ -259,5 +158,114 @@ void kernel_main(unsigned long boot_dev, unsigned long arm_m_type,
 		fclose(f);
 		multiboot_cfg_parse(buf);
 	}
+}
+
+void kernel_main(unsigned long boot_dev, unsigned long arm_m_type,
+                 unsigned long atags)
+{
+	// Hack for newer firmware - assume if atags not specified then they are at 0x100
+	// We also check the zero address in case this is true - see later
+	if(atags == 0x0)
+		atags = 0x100;
+	
+	atag_cmd_line = (void *)0;
+	_atags = atags;
+	_arm_m_type = arm_m_type;
+	UNUSED(boot_dev);
+
+	// First use the serial console
+	stdout_putc = split_putc;
+	stderr_putc = split_putc;
+	stream_putc = def_stream_putc;
+
+	output_init();
+	output_enable_uart();
+
+	// dump arguments to main
+#ifdef DEBUG
+	printf("MAIN: boot_dev: %x, arm_m_type: %i, atags: %x\n", boot_dev,
+			arm_m_type, atags);
+#endif
+
+	// try and interpret device tree/atags
+	if(fdt_check_header((const void *)atags) == 0)
+		conf_source = 3;
+	else if(fdt_check_header((const void *)0) == 0)
+		conf_source = 4;
+	else if(check_atags((const void *)atags) == 0)
+		conf_source = 1;
+	else if(check_atags((const void *)0) == 0)
+		conf_source = 2;
+
+	switch(conf_source)
+	{
+		case 1:
+		case 2:
+			// If using ATAGs, need to set up base adjust
+			// manually
+			if(arm_m_type == 0xc42)
+				base_adjust = BASE_ADJUST_V1;
+			else if(arm_m_type == 0xc43)
+				base_adjust = BASE_ADJUST_V2;
+			uart_init();
+#ifdef DEBUG
+			printf("ATAGS: detected\n");
+#endif
+
+			// Fall through
+		case 3:
+		case 4:
+			parse_atag_or_dtb(mem_cb);
+			break;
+		default:
+			/* Assume we are at least on RPi2 */
+			base_adjust = BASE_ADJUST_V2;
+			mem_cb(0, 512 * 1024 * 1024);
+			uart_init();
+			break;
+	}
+
+#ifdef ENABLE_FRAMEBUFFER
+	int result = fb_init();
+	if(result == 0)
+	{
+		puts("Successfully set up frame buffer");
+#ifdef DEBUG2
+		printf("FB: width: %i, height: %i, bpp: %i\n",
+			fb_get_width(), fb_get_height(),
+			fb_get_bpp());
+#endif
+	}
+	else
+	{
+		puts("Error setting up framebuffer:");
+		puthex(result);
+	}
+#endif
+
+	// Switch to the framebuffer for output
+	output_enable_fb();
+
+	// Allocate a log in memory
+#ifdef ENABLE_CONSOLE_LOGFILE
+	register_log_file(NULL, 0x1000);
+	output_enable_log();
+#endif
+
+	printf("Welcome to Rpi bootloader\n");
+	printf("Compiled on %s at %s\n", __DATE__, __TIME__);
+	printf("ARM system type is %x\n", arm_m_type);
+	if(atag_cmd_line != (void *)0)
+		printf("Command line: %s\n", atag_cmd_line);
+
+    // Register the various file systems
+	libfs_init();
+
+	// List devices
+	printf("MAIN: device list: ");
+	vfs_list_devices();
+	printf("\n");
+
+	find_and_run_config();
 }
 

--- a/main.c
+++ b/main.c
@@ -41,7 +41,11 @@
 
 uintptr_t _atags;
 unsigned long _arm_m_type;
+#ifdef __aarch64__
+uintptr_t base_adjust = BASE_ADJUST_V2;
+#else
 uintptr_t base_adjust = 0;
+#endif
 
 char rpi_boot_name[] = "rpi_boot";
 

--- a/main.c
+++ b/main.c
@@ -80,7 +80,7 @@ extern int (*stderr_putc)(int);
 extern int (*stream_putc)(int, FILE*);
 extern int def_stream_putc(int, FILE*);
 
-int cfg_parse(char *buf);
+int multiboot_cfg_parse(char *buf);
 
 int conf_source = 0;
 
@@ -257,7 +257,7 @@ void kernel_main(unsigned long boot_dev, unsigned long arm_m_type,
 		buf[flen] = 0;		// null terminate
 		fread(buf, 1, flen, f);
 		fclose(f);
-		cfg_parse(buf);
+		multiboot_cfg_parse(buf);
 	}
 }
 

--- a/mmio.c
+++ b/mmio.c
@@ -24,16 +24,16 @@
 
 extern void memory_barrier();
 
-extern uint32_t base_adjust;
+extern uintptr_t base_adjust;
 
-inline void mmio_write(uint32_t reg, uint32_t data)
+inline void mmio_write(uintptr_t reg, uint32_t data)
 {
 	memory_barrier();
 	*(volatile uint32_t *)(reg + base_adjust) = data;
 	memory_barrier();
 }
 
-inline uint32_t mmio_read(uint32_t reg)
+inline uint32_t mmio_read(uintptr_t reg)
 {
 	memory_barrier();
 	return *(volatile uint32_t *)(reg + base_adjust);

--- a/mmio.h
+++ b/mmio.h
@@ -24,8 +24,8 @@
 
 #include <stdint.h>
 
-void mmio_write(uint32_t reg, uint32_t data);
-uint32_t mmio_read(uint32_t reg);
+void mmio_write(uintptr_t reg, uint32_t data);
+uint32_t mmio_read(uintptr_t reg);
 
 #endif // !MMIO_H
 

--- a/multiboot.c
+++ b/multiboot.c
@@ -168,7 +168,7 @@ struct multiboot_arm_functions funcs =
 
 int multiboot_cfg_parse(char *buf)
 {
-	return config_parse(buf, methods);
+	return config_parse(buf, ' ', methods);
 }
 
 int method_multiboot(char *args)
@@ -177,7 +177,7 @@ int method_multiboot(char *args)
 	printf("Interpreting multiboot command\n");
 #endif
 	char *file, *cmd_line;
-	split_string(args, &file, &cmd_line);
+	split_string(args, ' ', &file, &cmd_line);
 
 	// First load up the first 8192 bytes to look for the multiboot header
 	FILE *fp = fopen(file, "r");
@@ -513,7 +513,7 @@ static void add_multiboot_modules()
 int method_module(char *args)
 {
 	char *file, *name;
-	split_string(args, &file, &name);
+	split_string(args, ' ', &file, &name);
 
 	if(!strcmp(name, empty_string))
 		name = file;
@@ -593,7 +593,7 @@ int method_boot(char *args)
 int method_kernel(char *args)
 {
 	char *file, *name;
-	split_string(args, &file, &name);
+	split_string(args, ' ', &file, &name);
 
 	FILE *fp = fopen(file, "r");
 	if(!fp)
@@ -776,7 +776,7 @@ int method_console_log(char *args)
 	char *endptr;
 	FILE *target;
 
-	split_string(args, &logName, &buffer_size);
+	split_string(args, ' ', &logName, &buffer_size);
 
 	// Determine if we are appending
 	if(logName[strlen(logName) - 1] == '+')

--- a/multiboot.h
+++ b/multiboot.h
@@ -29,7 +29,7 @@
 
 #include <stdint.h>
 
-#ifdef __ARMEL__
+#if defined(__ARMEL__) || defined(__aarch64__)
 #include <stddef.h>
 #include "timer.h"
 #include "output.h"
@@ -146,7 +146,7 @@ typedef struct multiboot_info
   uint32_t flags;
   uint32_t mem_lower;
   uint32_t mem_upper;
-#ifdef __ARMEL__
+#if defined(__ARMEL__) || defined(__aarch64__)
   char *boot_device;
   char *cmdline;
 #else
@@ -164,7 +164,7 @@ typedef struct multiboot_info
   uint32_t mmap_addr;
 
   uint32_t drives_length;
-#ifdef __ARMEL__
+#if defined(__ARMEL__) || defined(__aarch64__)
   char **drives_addr;
 #else
   uint32_t drives_addr;
@@ -174,7 +174,7 @@ typedef struct multiboot_info
   uint32_t config_table;
 
   /* Boot Loader Name */
-#ifdef __ARMEL__
+#if defined(__ARMEL__) || defined(__aarch64__)
   char *boot_loader_name;
 #else
   uint32_t boot_loader_name;
@@ -184,7 +184,7 @@ typedef struct multiboot_info
   uint32_t apm_table;
 
   /* Video */
-#ifdef __ARMEL__
+#if defined(__ARMEL__) || defined(__aarch64__)
   uint32_t fb_addr;
   uint32_t fb_size;
   uint32_t fb_pitch;

--- a/qemufw.c
+++ b/qemufw.c
@@ -1,0 +1,151 @@
+/* Copyright (C) 2017 by Alexander Graf <agraf@suse.de>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <libfdt.h>
+#include "uart.h"
+#include "atag.h"
+#include "fb.h"
+#include "console.h"
+#include "block.h"
+#include "vfs.h"
+#include "memchunk.h"
+#include "usb.h"
+#include "dwc_usb.h"
+#include "output.h"
+#include "log.h"
+#include "rpifdt.h"
+
+#include "config_parse.h"
+
+static int method_kernel(char *args);
+static int method_arm_control(char *args);
+
+#ifdef __aarch64__
+const char *boot_kernel = "kernel8.img";
+#else
+const char *boot_kernel = "kernel7.img";
+#endif
+uint32_t boot_arm_control;
+
+static const struct config_parse_method methods[] =
+{
+	{
+		.name = "kernel",
+		.method = method_kernel,
+	}, {
+		.name = "arm_control",
+		.method = method_arm_control,
+	}, {
+		.name = NULL,
+	},
+};
+
+static int method_kernel(char *args)
+{
+	boot_kernel = args;
+
+	return 0;
+}
+
+static int method_arm_control(char *args)
+{
+	char *endptr;
+	boot_arm_control = strtol(args, &endptr, 0);
+
+	return 0;
+}
+
+void find_and_run_config(void)
+{
+	char **dev = vfs_get_device_list();
+	FILE *f = NULL;
+	const char *fname = "/config.txt";
+	int fname_len = strlen(fname);
+	const char *found_cfg = NULL;
+	void (*entry)(long a, long b, long c);
+	char *kernel_fname;
+
+	/* The default load address for payloads is 0x80000 */
+	entry = (void*)0x80000;
+
+	/* Look for config.txt */
+	for (dev = vfs_get_device_list(); *dev; dev++) {
+		int dev_len = strlen(*dev);
+		char *new_str = (char *)malloc(dev_len + fname_len + 3);
+
+		sprintf(new_str, "(%s)%s", *dev, fname);
+		f = fopen(new_str, "r");
+
+		if (f) {
+			found_cfg = new_str;
+			break;
+		}
+
+		free(new_str);
+	}
+
+	if (f) {
+		long flen = fsize(f);
+		char *buf = (char *)malloc(flen+1);
+
+		printf("MAIN: Found bootloader configuration: %s\n", found_cfg);
+
+		/* Read full file */
+		buf[flen] = 0;
+		fread(buf, 1, flen, f);
+		fclose(f);
+
+		config_parse(buf, '=', methods);
+	} else {
+		printf("MAIN: No config.txt file found, using defaults\n");
+	}
+
+	if (*dev) {
+		kernel_fname = malloc(strlen(*dev) + strlen("/") + strlen(boot_kernel) + 1);
+		sprintf(kernel_fname, "(%s)/%s", *dev, boot_kernel);
+	} else {
+		kernel_fname = malloc(strlen("/") + strlen(boot_kernel) + 1);
+		sprintf(kernel_fname, "/%s", boot_kernel);
+	}
+
+	f = fopen(kernel_fname, "r");
+	if (!f) {
+		printf("Could not open kernel \"%s\". Aborting\n", boot_kernel);
+		return;
+	}
+
+#ifdef __aarch64__
+	if (!(boot_arm_control & 0x200)) {
+		printf("Sorry, I can not run 32bit kernels. Aborting\n");
+		return;
+	}
+#endif
+
+	fread((void*)entry, 1, fsize(f), f);
+	fclose(f);
+
+	printf("Calling kernel ...\n");
+	entry(0, 0, 0);
+}

--- a/qemufw.ld
+++ b/qemufw.ld
@@ -1,0 +1,50 @@
+ENTRY (Start)
+
+SECTIONS
+{
+	. = 0xb400000;
+	_start = .;
+	_text_start = .;
+	.text :
+	{
+		KEEP(*(.text.boot))
+		*(.text)
+	}
+	. = ALIGN(4096);
+	_text_end = .;
+	
+	_rodata_start = .;
+	.rodata :
+	{
+		*(.rodata)
+	}
+	. = ALIGN(4096);
+	_rodata_end = .;
+	
+	_data_start = .;
+	.data :
+	{
+		*(.data)
+	}
+	. = ALIGN(4096);
+	_data_end = .;
+
+	_bss_start = .;
+	.bss :
+	{
+		bss = .;
+		*(.bss)
+	}
+	. = ALIGN(4096);
+	_bss_end = .;
+
+	__exidx_start = .;
+	.ARM.exidx :
+	{
+		*(.ARM.exidx*)
+	}
+	__exidx_end = .;
+
+	_end = .;
+}
+

--- a/rpifdt.c
+++ b/rpifdt.c
@@ -26,7 +26,7 @@
 #include "util.h"
 
 extern const char *atag_cmd_line;
-extern uint32_t base_adjust;
+extern uintptr_t base_adjust;
 
 static uint32_t get_adjusted_address(const char *dtb, int node, uint32_t addr);
 

--- a/uart.c
+++ b/uart.c
@@ -25,8 +25,6 @@
 #include "uart.h"
 #include "timer.h"
 
-extern uint32_t base_adjust;
-
 #define GPIO_BASE 			0x20200000
 #define GPPUD 				0x94
 #define GPPUDCLK0 			0x98


### PR DESCRIPTION
I've made quite good progress I think. Please take another look :).

For now I really mostly care about the qemufw target that simply jumps to the loaded binary: No multiboot, no ELF loader. Would you prefer to have potentially broken loaders or rather just force disable them for aarch64?

You also need to adjust libdtc to use the CROSS_COMPILE variable instead to make it compile for aarch64.