### PR TITLE
Fix GCC warning build breaks

### DIFF
--- a/Makefile.rpi-boot.in
+++ b/Makefile.rpi-boot.in
@@ -30,6 +30,11 @@ CFLAGS += -mfloat-abi=soft
 CFLAGS += -fno-builtin
 CFLAGS += -fno-tree-loop-distribute-patterns
 
+ASFLAGS += -march=armv7ve
+ASFLAGS += -mcpu=arm1176jzf-s
+ASFLAGS += -mfloat-abi=soft
+
+
 #ifdef DEBUG
 CFLAGS += -g -O0
 ASSERT_OBJS = assert.o

--- a/malloc.c
+++ b/malloc.c
@@ -594,8 +594,13 @@ MAX_RELEASE_CHECK_RATE   default: 4095 unless not HAVE_MMAP
 #define MAX_SIZE_T           (~(size_t)0)
 
 #ifndef USE_LOCKS /* ensure true if spin or recursive locks set */
-#define USE_LOCKS  ((defined(USE_SPIN_LOCKS) && USE_SPIN_LOCKS != 0) || \
-                    (defined(USE_RECURSIVE_LOCKS) && USE_RECURSIVE_LOCKS != 0))
+
+#if (defined(USE_SPIN_LOCKS) && USE_SPIN_LOCKS != 0) || \
+        (defined(USE_RECURSIVE_LOCKS) && USE_RECURSIVE_LOCKS != 0)
+#define USE_LOCKS 1
+#else
+#define USE_LOCKS 0
+#endif
 #endif /* USE_LOCKS */
 
 #if USE_LOCKS /* Spin locks for gcc >= 4.1, older gcc on x86, MSC >= 1310 */

--- a/printf.c
+++ b/printf.c
@@ -194,6 +194,7 @@ reswitch:	switch (ch = (u_char)*fmt++) {
 				padc = '0';
 				goto reswitch;
 			}
+			// fallthrough
 		case '1': case '2': case '3': case '4':
 		case '5': case '6': case '7': case '8': case '9':
 				for (n = 0;; ++fmt) {
@@ -331,6 +332,7 @@ reswitch:	switch (ch = (u_char)*fmt++) {
 			goto handle_nosign;
 		case 'X':
 			upper = 1;
+			// fallthrough
 		case 'x':
 			base = 16;
 			goto handle_nosign;


### PR DESCRIPTION
In recently cloning and attempting to build this project using `arm-none-eabi-gcc` v9.2.1 (which appears to be the one available from `apt` in Ubuntu 20.04), I encountered some arguably pedantic warnings that were escalated to errors and broke the build.

Additionally, `boot.s` would not compile without some extra flags.

These commits resolve the issue without making any special appeal to a given version of GCC, and they do have a slight improvement in code readability.

Resolves https://github.com/jncronin/rpi-boot/issues/27